### PR TITLE
set zIndex to max

### DIFF
--- a/src/components/confetti.js
+++ b/src/components/confetti.js
@@ -49,7 +49,8 @@ const styles = StyleSheet.create({
   confetti: {
     position: 'absolute',
     left: 0,
-    bottom: 0
+    bottom: 0,
+    zIndex: Number.MAX_VALUE
   },
   rounded: {
     borderRadius: 100


### PR DESCRIPTION
# Description

To prevent fireworks from showing under other views

### Related issues

- [Confetti not rendering on top of Images](https://github.com/VincentCATILLON/react-native-confetti-cannon/issues/92)
